### PR TITLE
WebAssembly runtime support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = "wasmtime run"

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,4 @@ target/
 *.md
 *.txt
 .dockerignore
-Dockerfile
+Dockerfile*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git*
+target/
+
+*.lock
+*.md
+*.txt
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM rustlang/rust:nightly
+
+WORKDIR /app
+COPY . .
+
+RUN cargo test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM rustlang/rust:nightly
-
-WORKDIR /app
-COPY . .
-
-RUN cargo test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,10 @@
+FROM rustlang/rust:nightly
+
+RUN rustup target add wasm32-unknown-unknown && \
+    cargo install wasmtime-cli
+
+WORKDIR /app
+COPY . .
+
+RUN cargo test
+RUN cargo test --target wasm32-unknown-unknown

--- a/src/barriers.rs
+++ b/src/barriers.rs
@@ -157,6 +157,7 @@
 #[inline(always)]
 pub fn optimization_barrier_u8(mut value: u8) -> u8 {
     unsafe {
+        #[cfg(not(target_arch = "wasm32"))]
         std::arch::asm!(
             // Rust requires us to use every register defined, so we use it inside of a comment.
             "/* optimization_barrier_u8 {unused} */",
@@ -167,6 +168,14 @@ pub fn optimization_barrier_u8(mut value: u8) -> u8 {
 
             // By guaranteeing more invariants we improve the compiler's ability to optimize.
             // Since the assembly block is a no-op, we easily uphold all of these invariants.
+            options(pure, nomem, nostack, preserves_flags)
+        );
+
+        // WebAssembly only supports local class
+        #[cfg(target_arch = "wasm32")]
+        std::arch::asm!(
+            "/* optimization_barrier_u8 {unused} */",
+            unused = inout(local) value,
             options(pure, nomem, nostack, preserves_flags)
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@
 //! page](https://www.chosenplaintext.ca/open-source/rust-timing-shield/getting-started) for more
 //! information.
 
+#![feature(min_specialization)]
+#![cfg_attr(target_arch = "wasm32", feature(asm_experimental_arch))]
+
 #[cfg(test)]
 extern crate quickcheck;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 //! page](https://www.chosenplaintext.ca/open-source/rust-timing-shield/getting-started) for more
 //! information.
 
-#![feature(min_specialization)]
 #![cfg_attr(target_arch = "wasm32", feature(asm_experimental_arch))]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 //! information.
 
 #![cfg_attr(target_arch = "wasm32", feature(asm_experimental_arch))]
-
 #[cfg(test)]
 extern crate quickcheck;
 


### PR DESCRIPTION
We'd like to be able to use `timing-shield` in a client running on WebAssembly runtime. I've made some adjustments for that, in particular replacing `reg_byte` with WASM's `local`, which is its version of a [mutable "register"](http://troubles.md/wasm-is-not-a-stack-machine).

Do you think this approach is reasonable, and preserves constant-time guarantees?

The tests do pass, and I've provided a helper `Dockerfile.test` to run them, which we can remove if needed.

Thank you so much!